### PR TITLE
badSession agregada

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -30,11 +30,16 @@ async function connectToWhatsApp() {
       const reason = lastDisconnect?.error?.output?.statusCode;
 
       if (reason == DisconnectReason.loggedOut) {
-        console.log("Sesión cerrada en todos los dispositivos.");
+        console.log("Sesión cerrada en todos los dispositivos");
         fs.rmSync("auth_info_baileys", { recursive: true, force: true });
         console.log(
-          "Se borraron los datos de autenticación. Se dará un nuevo QR en la próxima ejecución."
+          "Se borraron los datos de autenticación. Se dará un nuevo QR en la próxima ejecución"
         );
+      } else if (statusCode === DisconnectReason.badSession) {
+        console.log("Sesión inválida. Eliminando credenciales");
+        fs.rmSync("auth_info_baileys", { recursive: true, force: true });
+      } else {
+        console.log(`Error (${statusCode}). Intentando reconectar`);
       }
 
       console.log("Reconectando...");


### PR DESCRIPTION
Se borran las credenciales si es un error 500, lo que significa una badSession. También en cualquier otro caso del porque se desconectó, simplemente se imprime el código de error en la consola.